### PR TITLE
refactor(modal): use a clone footer to prevent flickering

### DIFF
--- a/core/src/components/modal/animations/ios.enter.ts
+++ b/core/src/components/modal/animations/ios.enter.ts
@@ -17,23 +17,25 @@ const createEnterAnimation = () => {
 
   const wrapperAnimation = createAnimation().fromTo('transform', 'translateY(100vh)', 'translateY(0vh)');
 
-  return { backdropAnimation, wrapperAnimation, contentAnimation: undefined, footerAnimation: undefined };
+  return { backdropAnimation, wrapperAnimation, contentAnimation: undefined };
 };
 
 /**
  * iOS Modal Enter Animation for the Card presentation style
  */
 export const iosEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions): Animation => {
-  const { presentingEl, currentBreakpoint, animateContentHeight } = opts;
+  const { presentingEl, currentBreakpoint, scrollAtEdge } = opts;
   const root = getElementRoot(baseEl);
-  const { wrapperAnimation, backdropAnimation, contentAnimation, footerAnimation } =
-    currentBreakpoint !== undefined ? createSheetEnterAnimation(baseEl, opts) : createEnterAnimation();
+  const { wrapperAnimation, backdropAnimation, contentAnimation } =
+    currentBreakpoint !== undefined ? createSheetEnterAnimation(opts) : createEnterAnimation();
 
   backdropAnimation.addElement(root.querySelector('ion-backdrop')!);
 
   wrapperAnimation.addElement(root.querySelectorAll('.modal-wrapper, .modal-shadow')!).beforeStyles({ opacity: 1 });
 
-  contentAnimation?.addElement(baseEl.querySelector('.ion-page')!);
+  // The content animation is only added if scrolling is enabled for
+  // all the breakpoints.
+  !scrollAtEdge && contentAnimation?.addElement(baseEl.querySelector('.ion-page')!);
 
   const baseAnimation = createAnimation('entering-base')
     .addElement(baseEl)
@@ -41,29 +43,51 @@ export const iosEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptio
     .duration(500)
     .addAnimation([wrapperAnimation])
     .beforeAddWrite(() => {
-      if (!animateContentHeight) return;
+      if (scrollAtEdge) {
+        // Scroll can only be done when the modal is fully expanded.
+        return;
+      }
 
+      /**
+       * There are some browsers that causes flickering when
+       * dragging the content when scroll is enabled at every
+       * breakpoint. This is due to the wrapper element being
+       * transformed off the screen and having a snap animation.
+       *
+       * A workaround is to clone the footer element and append
+       * it outside of the wrapper element. This way, the footer
+       * is still visible and the drag can be done without
+       * flickering. The original footer is hidden until the modal
+       * is dismissed. This maintains the animation of the footer
+       * when the modal is dismissed.
+       *
+       * The workaround needs to be done before the animation starts
+       * so there are no flickering issues.
+       */
       const ionFooter = baseEl.querySelector('ion-footer');
-      if (ionFooter && footerAnimation) {
+      /**
+       * This check is needed to prevent more than one footer
+       * from being appended to the shadow root.
+       * Otherwise, iOS and MD enter animations would append
+       * the footer twice.
+       */
+      const ionFooterAlreadyAppended = baseEl.shadowRoot!.querySelector('ion-footer');
+      if (ionFooter && !ionFooterAlreadyAppended) {
         const footerHeight = ionFooter.clientHeight;
-        const clonedFooter = ionFooter.cloneNode(true) as HTMLElement;
-        baseEl.shadowRoot!.appendChild(clonedFooter);
-        ionFooter.remove();
+        const clonedFooter = ionFooter.cloneNode(true) as HTMLIonFooterElement;
 
-        // add padding bottom to the .ion-page element to be
-        // the same as the cloned footer height
+        baseEl.shadowRoot!.appendChild(clonedFooter);
+        ionFooter.style.setProperty('display', 'none');
+        ionFooter.setAttribute('aria-hidden', 'true');
+
+        // Padding is added to prevent some content from being hidden.
         const page = baseEl.querySelector('.ion-page') as HTMLElement;
         page.style.setProperty('padding-bottom', `${footerHeight}px`);
-        footerAnimation.addElement(root.querySelector('ion-footer')!);
-    }
-  });
+      }
+    });
 
-  if (animateContentHeight && contentAnimation) {
+  if (contentAnimation) {
     baseAnimation.addAnimation(contentAnimation);
-  }
-
-  if (animateContentHeight && footerAnimation) {
-    baseAnimation.addAnimation(footerAnimation);
   }
 
   if (presentingEl) {

--- a/core/src/components/modal/animations/ios.leave.ts
+++ b/core/src/components/modal/animations/ios.leave.ts
@@ -12,7 +12,7 @@ const createLeaveAnimation = () => {
 
   const wrapperAnimation = createAnimation().fromTo('transform', 'translateY(0vh)', 'translateY(100vh)');
 
-  return { backdropAnimation, wrapperAnimation, footerAnimation: undefined };
+  return { backdropAnimation, wrapperAnimation };
 };
 
 /**
@@ -21,24 +21,18 @@ const createLeaveAnimation = () => {
 export const iosLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions, duration = 500): Animation => {
   const { presentingEl, currentBreakpoint } = opts;
   const root = getElementRoot(baseEl);
-  const { wrapperAnimation, backdropAnimation, footerAnimation } =
-    currentBreakpoint !== undefined ? createSheetLeaveAnimation(baseEl, opts) : createLeaveAnimation();
+  const { wrapperAnimation, backdropAnimation } =
+    currentBreakpoint !== undefined ? createSheetLeaveAnimation(opts) : createLeaveAnimation();
 
   backdropAnimation.addElement(root.querySelector('ion-backdrop')!);
 
   wrapperAnimation.addElement(root.querySelectorAll('.modal-wrapper, .modal-shadow')!).beforeStyles({ opacity: 1 });
-
-  footerAnimation?.addElement(root.querySelector('ion-footer')!);
 
   const baseAnimation = createAnimation('leaving-base')
     .addElement(baseEl)
     .easing('cubic-bezier(0.32,0.72,0,1)')
     .duration(duration)
     .addAnimation(wrapperAnimation);
-
-  if (footerAnimation) {
-    baseAnimation.addAnimation(footerAnimation);
-  }
 
   if (presentingEl) {
     const isMobile = window.innerWidth < 768;

--- a/core/src/components/modal/animations/md.enter.ts
+++ b/core/src/components/modal/animations/md.enter.ts
@@ -19,53 +19,77 @@ const createEnterAnimation = () => {
     { offset: 1, opacity: 1, transform: `translateY(0px)` },
   ]);
 
-  return { backdropAnimation, wrapperAnimation, contentAnimation: undefined, footerAnimation: undefined };
+  return { backdropAnimation, wrapperAnimation, contentAnimation: undefined };
 };
 
 /**
  * Md Modal Enter Animation
  */
 export const mdEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions): Animation => {
-  const { currentBreakpoint, animateContentHeight } = opts;
+  const { currentBreakpoint, scrollAtEdge } = opts;
   const root = getElementRoot(baseEl);
-  const { wrapperAnimation, backdropAnimation, contentAnimation, footerAnimation } =
-    currentBreakpoint !== undefined ? createSheetEnterAnimation(baseEl, opts) : createEnterAnimation();
+  const { wrapperAnimation, backdropAnimation, contentAnimation } =
+    currentBreakpoint !== undefined ? createSheetEnterAnimation(opts) : createEnterAnimation();
 
   backdropAnimation.addElement(root.querySelector('ion-backdrop')!);
 
   wrapperAnimation.addElement(root.querySelector('.modal-wrapper')!);
 
-  contentAnimation?.addElement(baseEl.querySelector('.ion-page')!);
+  // The content animation is only added if scrolling is enabled for
+  // all the breakpoints.
+  scrollAtEdge && contentAnimation?.addElement(baseEl.querySelector('.ion-page')!);
 
   const baseAnimation = createAnimation()
-  .addElement(baseEl)
-  .easing('cubic-bezier(0.36,0.66,0.04,1)')
-  .duration(280)
-  .addAnimation([backdropAnimation, wrapperAnimation])
-  .beforeAddWrite(() => {
-    if (!animateContentHeight) return;
-
-    const ionFooter = baseEl.querySelector('ion-footer');
-    if (ionFooter && footerAnimation) {
-      const footerHeight = ionFooter.clientHeight;
-      const clonedFooter = ionFooter.cloneNode(true) as HTMLElement;
-      baseEl.shadowRoot!.appendChild(clonedFooter);
-      ionFooter.remove();
-
-      // add padding bottom to the .ion-page element to be
-      // the same as the cloned footer height
-      const page = baseEl.querySelector('.ion-page') as HTMLElement;
-      page.style.setProperty('padding-bottom', `${footerHeight}px`);
-      footerAnimation.addElement(root.querySelector('ion-footer')!);
+    .addElement(baseEl)
+    .easing('cubic-bezier(0.36,0.66,0.04,1)')
+    .duration(280)
+    .addAnimation([backdropAnimation, wrapperAnimation])
+    .beforeAddWrite(() => {
+      if (scrollAtEdge) {
+        // Scroll can only be done when the modal is fully expanded.
+        return;
       }
-  });
 
-  if (animateContentHeight && contentAnimation) {
+      /**
+       * There are some browsers that causes flickering when
+       * dragging the content when scroll is enabled at every
+       * breakpoint. This is due to the wrapper element being
+       * transformed off the screen and having a snap animation.
+       *
+       * A workaround is to clone the footer element and append
+       * it outside of the wrapper element. This way, the footer
+       * is still visible and the drag can be done without
+       * flickering. The original footer is hidden until the modal
+       * is dismissed. This maintains the animation of the footer
+       * when the modal is dismissed.
+       *
+       * The workaround needs to be done before the animation starts
+       * so there are no flickering issues.
+       */
+      const ionFooter = baseEl.querySelector('ion-footer');
+      /**
+       * This check is needed to prevent more than one footer
+       * from being appended to the shadow root.
+       * Otherwise, iOS and MD enter animations would append
+       * the footer twice.
+       */
+      const ionFooterAlreadyAppended = baseEl.shadowRoot!.querySelector('ion-footer');
+      if (ionFooter && !ionFooterAlreadyAppended) {
+        const footerHeight = ionFooter.clientHeight;
+        const clonedFooter = ionFooter.cloneNode(true) as HTMLIonFooterElement;
+
+        baseEl.shadowRoot!.appendChild(clonedFooter);
+        ionFooter.style.setProperty('display', 'none');
+        ionFooter.setAttribute('aria-hidden', 'true');
+
+        // Padding is added to prevent some content from being hidden.
+        const page = baseEl.querySelector('.ion-page') as HTMLElement;
+        page.style.setProperty('padding-bottom', `${footerHeight}px`);
+      }
+    });
+
+  if (contentAnimation) {
     baseAnimation.addAnimation(contentAnimation);
-  }
-
-  if (animateContentHeight && footerAnimation) {
-    baseAnimation.addAnimation(footerAnimation);
   }
 
   return baseAnimation;

--- a/core/src/components/modal/animations/md.leave.ts
+++ b/core/src/components/modal/animations/md.leave.ts
@@ -14,7 +14,7 @@ const createLeaveAnimation = () => {
     { offset: 1, opacity: 0, transform: 'translateY(40px)' },
   ]);
 
-  return { backdropAnimation, wrapperAnimation, footerAnimation: undefined };
+  return { backdropAnimation, wrapperAnimation };
 };
 
 /**
@@ -23,21 +23,16 @@ const createLeaveAnimation = () => {
 export const mdLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions): Animation => {
   const { currentBreakpoint } = opts;
   const root = getElementRoot(baseEl);
-  const { wrapperAnimation, backdropAnimation, footerAnimation } =
-    currentBreakpoint !== undefined ? createSheetLeaveAnimation(baseEl, opts) : createLeaveAnimation();
+  const { wrapperAnimation, backdropAnimation } =
+    currentBreakpoint !== undefined ? createSheetLeaveAnimation(opts) : createLeaveAnimation();
 
   backdropAnimation.addElement(root.querySelector('ion-backdrop')!);
   wrapperAnimation.addElement(root.querySelector('.modal-wrapper')!);
-  footerAnimation?.addElement(root.querySelector('ion-footer')!);
 
   const baseAnimation = createAnimation()
     .easing('cubic-bezier(0.47,0,0.745,0.715)')
     .duration(200)
     .addAnimation([backdropAnimation, wrapperAnimation]);
-
-  if (footerAnimation) {
-    baseAnimation.addAnimation(footerAnimation);
-  }
 
   return baseAnimation;
 };

--- a/core/src/components/modal/animations/sheet.ts
+++ b/core/src/components/modal/animations/sheet.ts
@@ -4,7 +4,7 @@ import type { ModalAnimationOptions } from '../modal-interface';
 import { getBackdropValueForSheet } from '../utils';
 
 export const createSheetEnterAnimation = (opts: ModalAnimationOptions) => {
-  const { currentBreakpoint, backdropBreakpoint } = opts;
+  const { currentBreakpoint, backdropBreakpoint, scrollAtEdge } = opts;
 
   /**
    * If the backdropBreakpoint is undefined, then the backdrop
@@ -32,10 +32,12 @@ export const createSheetEnterAnimation = (opts: ModalAnimationOptions) => {
   /**
    * This allows the content to be scrollable at any breakpoint.
    */
-  const contentAnimation = createAnimation('contentAnimation').keyframes([
-    { offset: 0, opacity: 1, maxHeight: `${(1 - currentBreakpoint!) * 100}%` },
-    { offset: 1, opacity: 1, maxHeight: `${currentBreakpoint! * 100}%` },
-  ]);
+  const contentAnimation = !scrollAtEdge
+    ? createAnimation('contentAnimation').keyframes([
+        { offset: 0, opacity: 1, maxHeight: `${(1 - currentBreakpoint!) * 100}%` },
+        { offset: 1, opacity: 1, maxHeight: `${currentBreakpoint! * 100}%` },
+      ])
+    : undefined;
 
   return { wrapperAnimation, backdropAnimation, contentAnimation };
 };

--- a/core/src/components/modal/animations/sheet.ts
+++ b/core/src/components/modal/animations/sheet.ts
@@ -3,7 +3,7 @@ import { createAnimation } from '@utils/animation/animation';
 import type { ModalAnimationOptions } from '../modal-interface';
 import { getBackdropValueForSheet } from '../utils';
 
-export const createSheetEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions) => {
+export const createSheetEnterAnimation = (opts: ModalAnimationOptions) => {
   const { currentBreakpoint, backdropBreakpoint } = opts;
 
   /**
@@ -29,32 +29,18 @@ export const createSheetEnterAnimation = (baseEl: HTMLElement, opts: ModalAnimat
     { offset: 1, opacity: 1, transform: `translateY(${100 - currentBreakpoint! * 100}%)` },
   ]);
 
+  /**
+   * This allows the content to be scrollable at any breakpoint.
+   */
   const contentAnimation = createAnimation('contentAnimation').keyframes([
     { offset: 0, opacity: 1, maxHeight: `${(1 - currentBreakpoint!) * 100}%` },
     { offset: 1, opacity: 1, maxHeight: `${currentBreakpoint! * 100}%` },
   ]);
 
-  const headerHeight = baseEl.querySelector('ion-header')?.clientHeight ?? 0;
-
-  const footerHeight = baseEl.querySelector('ion-footer')?.clientHeight
-    ?? baseEl.shadowRoot?.querySelector('ion-footer')?.clientHeight ?? 0;
-
-  const wrapperHeight = baseEl.shadowRoot?.querySelector('.modal-wrapper, .modal-shadow')?.clientHeight ?? 100;
-
-  const footerOffset = parseFloat(((footerHeight ? (footerHeight / wrapperHeight) : 0)).toFixed(2));
-
-  const headerOffset = parseFloat(((headerHeight ? (headerHeight / wrapperHeight) : 0)).toFixed(2));
-
-  const footerAnimation = createAnimation('footerAnimation').keyframes([
-    { offset: 0, opacity: 1, transform: `translateY(${footerHeight}px)` },
-    { offset: headerOffset, opacity: 1, transform: `translateY(${footerHeight}px)` },
-    { offset: ((footerOffset + headerOffset) * 2), opacity: 1, transform: 'translateY(0)' },
-  ]);
-
-  return { wrapperAnimation, backdropAnimation, contentAnimation, footerAnimation };
+  return { wrapperAnimation, backdropAnimation, contentAnimation };
 };
 
-export const createSheetLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimationOptions) => {
+export const createSheetLeaveAnimation = (opts: ModalAnimationOptions) => {
   const { currentBreakpoint, backdropBreakpoint } = opts;
 
   /**
@@ -86,22 +72,5 @@ export const createSheetLeaveAnimation = (baseEl: HTMLElement, opts: ModalAnimat
     { offset: 1, opacity: 1, transform: `translateY(100%)` },
   ]);
 
-  const headerHeight = baseEl.querySelector('ion-header')?.clientHeight ?? 0;
-
-  const footerHeight = baseEl.querySelector('ion-footer')?.clientHeight
-    ?? baseEl.shadowRoot?.querySelector('ion-footer')?.clientHeight ?? 0;
-
-  const wrapperHeight = baseEl.shadowRoot?.querySelector('.modal-wrapper, .modal-shadow')?.clientHeight ?? 100;
-
-  const footerOffset = parseFloat(((footerHeight ? (footerHeight / wrapperHeight) : 0)).toFixed(2));
-
-  const headerOffset = parseFloat(((headerHeight ? (headerHeight / wrapperHeight) : 0)).toFixed(2));
-
-  const footerAnimation = createAnimation('footerAnimation').keyframes([
-    { offset: 0, opacity: 1, transform: 'translateY(0)' },
-    { offset: (1 - (footerOffset + headerOffset) * 2), opacity: 1, transform: 'translateY(0)' },
-    { offset: (1), opacity: 1, transform: `translateY(${footerHeight}px)` },
-  ]);
-
-  return { wrapperAnimation, backdropAnimation, footerAnimation };
+  return { wrapperAnimation, backdropAnimation };
 };

--- a/core/src/components/modal/gestures/sheet.ts
+++ b/core/src/components/modal/gestures/sheet.ts
@@ -54,12 +54,6 @@ export const createSheetGesture = (
   onDismiss: () => void,
   onBreakpointChange: (breakpoint: number) => void
 ) => {
-  const contentEl = baseEl.querySelector('ion-content');
-  const height = wrapperEl.clientHeight;
-  const footerEl = baseEl.shadowRoot?.querySelector('ion-footer');
-  const footerHeight = footerEl?.clientHeight ?? 0;
-  const footerDismissalPercentage = parseFloat(( 1 - (footerHeight ? (footerHeight / height) : 0)).toFixed(2));
-
   // Defaults for the sheet swipe animation
   const defaultBackdrop = [
     { offset: 0, opacity: 'var(--backdrop-opacity)' },
@@ -82,13 +76,10 @@ export const createSheetGesture = (
       { offset: 0, maxHeight: '100%' },
       { offset: 1, maxHeight: '0%' },
     ],
-    FOOTER_KEYFRAMES: [
-      { offset: 0, transform: 'translateY(0)' },
-      { offset: footerDismissalPercentage, transform: 'translateY(0)' },
-      { offset: 1, transform: `translateY(${footerHeight}px)` },
-    ],
   };
 
+  const contentEl = baseEl.querySelector('ion-content');
+  const height = wrapperEl.clientHeight;
   let currentBreakpoint = initialBreakpoint;
   let offset = 0;
   let canDismissBlocksGesture = false;
@@ -98,11 +89,6 @@ export const createSheetGesture = (
   const wrapperAnimation = animation.childAnimations.find((ani) => ani.id === 'wrapperAnimation');
   const backdropAnimation = animation.childAnimations.find((ani) => ani.id === 'backdropAnimation');
   const contentAnimation = animation.childAnimations.find((ani) => ani.id === 'contentAnimation');
-  const footerAnimation = animation.childAnimations.find((ani) => ani.id === 'footerAnimation');
-
-  if (footerAnimation && footerEl) {
-    // footerAnimation.addElement(footerEl);
-  }
 
   const enableBackdrop = () => {
     baseEl.style.setProperty('pointer-events', 'auto');
@@ -142,8 +128,6 @@ export const createSheetGesture = (
     wrapperAnimation.keyframes([...SheetDefaults.WRAPPER_KEYFRAMES]);
     backdropAnimation.keyframes([...SheetDefaults.BACKDROP_KEYFRAMES]);
     contentAnimation?.keyframes([...SheetDefaults.CONTENT_KEYFRAMES]);
-    footerAnimation?.keyframes([...SheetDefaults.FOOTER_KEYFRAMES]);
-
     animation.progressStart(true, 1 - currentBreakpoint);
 
     /**
@@ -368,13 +352,6 @@ export const createSheetGesture = (
         ]);
       }
 
-      if (footerAnimation) {
-        footerAnimation.keyframes([
-          { offset: 0, transform: 'translateY(0)' },
-          { offset: 0.85, transform: 'translateY(0)' },
-          { offset: footerDismissalPercentage, transform: `translateY(${!shouldRemainOpen ? footerHeight : 0}px)` },
-        ])
-      }
       animation.progressStep(0);
     }
 
@@ -387,6 +364,20 @@ export const createSheetGesture = (
     if (shouldPreventDismiss) {
       handleCanDismiss(baseEl, animation);
     } else if (!shouldRemainOpen) {
+      if (!scrollAtEdge) {
+        const clonedFooter = wrapperEl.nextElementSibling as HTMLIonFooterElement;
+        // get the original footer, which is a child of
+        const originalFooter = baseEl.querySelector('ion-footer') as HTMLIonFooterElement;
+        // hide the cloned footer
+        clonedFooter.style.setProperty('display', 'none');
+        // add the aria-hidden attribute to the cloned footer
+        clonedFooter.setAttribute('aria-hidden', 'true');
+        // display the original footer, remove the inline style display: none
+        originalFooter.style.removeProperty('display');
+        // remove the aria-hidden attribute
+        originalFooter.removeAttribute('aria-hidden');
+      }
+
       onDismiss();
     }
 
@@ -419,7 +410,6 @@ export const createSheetGesture = (
                   wrapperAnimation.keyframes([...SheetDefaults.WRAPPER_KEYFRAMES]);
                   backdropAnimation.keyframes([...SheetDefaults.BACKDROP_KEYFRAMES]);
                   contentAnimation?.keyframes([...SheetDefaults.CONTENT_KEYFRAMES]);
-                  footerAnimation?.keyframes([...SheetDefaults.FOOTER_KEYFRAMES]);
                   animation.progressStart(true, 1 - snapToBreakpoint);
                   currentBreakpoint = snapToBreakpoint;
                   onBreakpointChange(currentBreakpoint);

--- a/core/src/components/modal/modal-interface.ts
+++ b/core/src/components/modal/modal-interface.ts
@@ -31,7 +31,7 @@ export interface ModalAnimationOptions {
   presentingEl?: HTMLElement;
   currentBreakpoint?: number;
   backdropBreakpoint?: number;
-  animateContentHeight?: boolean;
+  scrollAtEdge?: boolean;
 }
 
 export interface ModalBreakpointChangeEventDetail {

--- a/core/src/components/modal/modal.scss
+++ b/core/src/components/modal/modal.scss
@@ -167,9 +167,9 @@ ion-backdrop {
   bottom: 0;
 }
 
-// :host(.modal-sheet.modal-scroll-all) ion-footer {
-//   position: absolute;
-//   bottom: 0;
+:host(.modal-sheet.modal-scroll-all) ion-footer {
+  position: absolute;
+  bottom: 0;
 
-//   width: var(--width);
-// }
+  width: var(--width);
+}

--- a/core/src/components/modal/modal.scss
+++ b/core/src/components/modal/modal.scss
@@ -167,9 +167,9 @@ ion-backdrop {
   bottom: 0;
 }
 
-:host(.modal-sheet) ion-footer {
-  position: absolute;
-  bottom: 0;
+// :host(.modal-sheet.modal-scroll-all) ion-footer {
+//   position: absolute;
+//   bottom: 0;
 
-  width: var(--width);
-}
+//   width: var(--width);
+// }

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -573,7 +573,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
       presentingEl: presentingElement,
       currentBreakpoint: this.initialBreakpoint,
       backdropBreakpoint: this.backdropBreakpoint,
-      animateContentHeight: !this.scrollAtEdge
+      scrollAtEdge: this.scrollAtEdge,
     });
 
     /* tslint:disable-next-line */
@@ -680,7 +680,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
       presentingEl: this.presentingElement,
       currentBreakpoint: initialBreakpoint,
       backdropBreakpoint,
-      animateContentHeight: !this.scrollAtEdge,
+      scrollAtEdge: this.scrollAtEdge,
     }));
 
     ani.progressStart(true, 1);
@@ -941,9 +941,17 @@ export class Modal implements ComponentInterface, OverlayInterface {
   };
 
   render() {
-    const { handle, isSheetModal, presentingElement, htmlAttributes, handleBehavior, inheritedAttributes, focusTrap } =
-      this;
-
+    const {
+      handle,
+      isSheetModal,
+      presentingElement,
+      htmlAttributes,
+      handleBehavior,
+      inheritedAttributes,
+      focusTrap,
+      scrollAtEdge,
+    } = this;
+    console.log('isSheetModal', isSheetModal, 'scrollAtEdge', scrollAtEdge, 'both', isSheetModal && !scrollAtEdge);
     const showHandle = handle !== false && isSheetModal;
     const mode = getIonMode(this);
     const isCardModal = presentingElement !== undefined && mode === 'ios';
@@ -962,6 +970,7 @@ export class Modal implements ComponentInterface, OverlayInterface {
           ['modal-default']: !isCardModal && !isSheetModal,
           [`modal-card`]: isCardModal,
           [`modal-sheet`]: isSheetModal,
+          [`modal-scroll-all`]: isSheetModal && !scrollAtEdge,
           'overlay-hidden': true,
           [FOCUS_TRAP_DISABLE_CLASS]: focusTrap === false,
           ...getClassMap(this.cssClass),
@@ -1035,10 +1044,10 @@ interface ModalOverlayOptions {
   backdropBreakpoint: number;
 
   /**
-   * Whether or not the modal should animate
-   * content's max-height.
+   * Whether or not the modal should scroll
+   * only when fully expanded.
    */
-  animateContentHeight?: boolean;
+  scrollAtEdge?: boolean;
 }
 
 type ModalPresentOptions = ModalOverlayOptions;

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -951,7 +951,6 @@ export class Modal implements ComponentInterface, OverlayInterface {
       focusTrap,
       scrollAtEdge,
     } = this;
-    console.log('isSheetModal', isSheetModal, 'scrollAtEdge', scrollAtEdge, 'both', isSheetModal && !scrollAtEdge);
     const showHandle = handle !== false && isSheetModal;
     const mode = getIonMode(this);
     const isCardModal = presentingElement !== undefined && mode === 'ios';

--- a/core/src/components/modal/test/sheet/index.html
+++ b/core/src/components/modal/test/sheet/index.html
@@ -101,10 +101,10 @@
             Present Sheet Modal (Max breakpoint is not 1)
           </button>
           <button
-            id="custom-breakpoint-modal"
+            id="scroll-at-edge-modal"
             onclick="presentModal({ initialBreakpoint: 0.5, breakpoints: [0, 0.25, 0.5, 0.75, 1], scrollAtEdge: false })"
           >
-            Present Sheet Modal (scrollAtEdge)
+            Present Sheet Modal (Scroll at any breakpoint)
           </button>
           <button
             id="custom-backdrop-modal"
@@ -193,9 +193,7 @@
       <ion-footer>
         <ion-toolbar>
           <ion-title>Footer</ion-title>
-          <ion-button id="add-content">Add More Content</ion-button>
         </ion-toolbar>
-        <div id="dynamic-content"></div>
       </ion-footer>
       `;
 
@@ -222,19 +220,6 @@
         button.addEventListener('click', () => {
           modalElement.dismiss();
         });
-
-        const buttonAdd = element.querySelector('#add-content');
-        buttonAdd.addEventListener('click', () => {
-          const dynamicContent = modalElement.shadowRoot.querySelector('#dynamic-content');
-          console.log(modalElement.shadowRoot)
-          const newToolbar = document.createElement('ion-toolbar');
-          newToolbar.innerHTML = `
-            <ion-title>Additional Content</ion-title>
-          `;
-          dynamicContent.appendChild(newToolbar);
-          dynamicContent
-        });
-
 
         document.body.appendChild(modalElement);
         return modalElement;


### PR DESCRIPTION
The implementation can be simplified by using a cloned footer and swapping based on dismissal. Comments have been added that explains the changes further.